### PR TITLE
FEATURE KMM-94: Transparent crashlytics traces for iOS and Android

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,4 +19,6 @@ dependencies {
     implementation(libs.gradleplugins.detekt)
     implementation(libs.gradleplugins.mokoresources)
     implementation(libs.gradleplugins.kswift)
+    implementation(libs.gradleplugins.nativecoroutines)
+    implementation(libs.gradleplugins.crashkios)
 }

--- a/buildSrc/src/main/kotlin/multiplatform-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiplatform-config.gradle.kts
@@ -10,18 +10,9 @@ plugins {
 
 kotlin {
     android()
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "shared"
-            export("dev.icerock.moko:resources:0.20.1")
-            export("dev.icerock.moko:graphics:0.9.0") // toUIColor here
-        }
-    }
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting

--- a/buildSrc/src/main/kotlin/native-cocoapods-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/native-cocoapods-config.gradle.kts
@@ -14,11 +14,11 @@ kotlin {
         summary = "Some description for a Kotlin/Native module"
         homepage = "https://github.com/maltsev-gorskij/MultiplatformSandbox_kmm"
         name = "shared"
+        ios.deploymentTarget = "13.0"
 
         framework {
             baseName = "shared"
             isStatic = false
-
             export("dev.icerock.moko:resources:0.20.1")
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ napier = "2.6.1"
 moko_resources = "0.20.1" # if version changes, update version in native-cocoapods-config.kts
 moko_paging = "0.7.2"
 moko_kswift = "0.6.1"
+nativecoroutines = "0.13.3"
+crashkios = "0.8.1"
 
 [libraries]
 gradleplugins-android = { module = "com.android.tools.build:gradle", version.ref = "android_plugin" }
@@ -26,6 +28,8 @@ gradleplugins-cocoapods = { module = "org.jetbrains.kotlin.native.cocoapods:org.
 gradleplugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradleplugins-mokoresources = { module = "dev.icerock.moko:resources-generator", version.ref = "moko_resources" }
 gradleplugins-kswift = { module = "dev.icerock.moko:kswift-gradle-plugin", version.ref = "moko_kswift" }
+gradleplugins-nativecoroutines = { module = "com.rickclephas.kmp:kmp-nativecoroutines-gradle-plugin", version.ref = "nativecoroutines" }
+gradleplugins-crashkios = { module = "co.touchlab.crashkios.crashlyticslink:co.touchlab.crashkios.crashlyticslink.gradle.plugin", version.ref = "crashkios" }
 
 sqldelight-common = { module = "com.squareup.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-android = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
@@ -56,6 +60,8 @@ multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", vers
 detekt-cli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
 
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
+
+crashkios = { module = "co.touchlab.crashkios:crashlytics", version.ref = "crashkios" }
 
 [bundles]
 ktor = [

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -12,7 +12,8 @@ plugins {
     id("moko-kswift-config")
 
     // Dependencies pluging
-    id("com.rickclephas.kmp.nativecoroutines") version "0.13.3"
+    id("com.rickclephas.kmp.nativecoroutines")
+    id("co.touchlab.crashkios.crashlyticslink")
 }
 
 kotlin {
@@ -28,6 +29,7 @@ kotlin {
                 api(libs.moko.resources.common)
                 implementation(libs.napier)
                 implementation(libs.moko.paging)
+                implementation(libs.crashkios)
             }
         }
 

--- a/shared/proguard-rules.pro
+++ b/shared/proguard-rules.pro
@@ -25,7 +25,6 @@
 # Keep all Enum classes
 -keep enum *
 
-
 ### Kotlinx Serialization ###
 
 # Keep `Companion` object fields of serializable classes.

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'Some description for a Kotlin/Native module'
     spec.vendored_frameworks      = 'build/cocoapods/framework/shared.framework'
     spec.libraries                = 'c++'
-                
+    spec.ios.deployment_target = '13.0'
                 
                 
     spec.pod_target_xcconfig = {

--- a/shared/src/androidMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/FirebaseInitializer.kt
+++ b/shared/src/androidMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/FirebaseInitializer.kt
@@ -1,0 +1,10 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.initializers
+
+import co.touchlab.crashkios.crashlytics.enableCrashlytics
+import ru.lyrian.kotlinmultiplatformsandbox.core.common.build_info.BuildInfo
+
+internal actual class FirebaseInitializer {
+    actual fun init() {
+        if(!BuildInfo.isDebug) enableCrashlytics()
+    }
+}

--- a/shared/src/androidMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/LoggerInitializer.kt
+++ b/shared/src/androidMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/LoggerInitializer.kt
@@ -2,7 +2,15 @@ package ru.lyrian.kotlinmultiplatformsandbox.core.initializers
 
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import ru.lyrian.kotlinmultiplatformsandbox.core.common.build_info.BuildInfo
+import ru.lyrian.kotlinmultiplatformsandbox.core.common.logger.NapierCrashlyticsLogger
 
 internal actual class LoggerInitializer {
-    actual fun init() = Napier.base(DebugAntilog())
+    actual fun init() {
+        if(BuildInfo.isDebug) {
+            Napier.base(antilog = DebugAntilog())
+        } else {
+            Napier.base(antilog = NapierCrashlyticsLogger())
+        }
+    }
 }

--- a/shared/src/androidMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/FirebaseModule.kt
+++ b/shared/src/androidMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/FirebaseModule.kt
@@ -1,0 +1,10 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.initializers.di
+
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+import ru.lyrian.kotlinmultiplatformsandbox.core.initializers.FirebaseInitializer
+
+actual val firebaseModule: Module = module {
+    factoryOf(::FirebaseInitializer)
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/common/logger/NapierCrashlyticsLogger.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/common/logger/NapierCrashlyticsLogger.kt
@@ -1,0 +1,20 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.common.logger
+
+import co.touchlab.crashkios.crashlytics.CrashlyticsKotlin
+import io.github.aakira.napier.Antilog
+import io.github.aakira.napier.LogLevel
+
+class NapierCrashlyticsLogger : Antilog() {
+    override fun performLog(
+        priority: LogLevel,
+        tag: String?,
+        throwable: Throwable?,
+        message: String?
+    ) {
+        if (priority < LogLevel.ERROR) return
+
+        throwable?.let {
+            CrashlyticsKotlin.sendHandledException(it)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/common/logger/SharedLogger.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/common/logger/SharedLogger.kt
@@ -2,7 +2,6 @@ package ru.lyrian.kotlinmultiplatformsandbox.core.common.logger
 
 import io.github.aakira.napier.LogLevel
 import io.github.aakira.napier.Napier
-import ru.lyrian.kotlinmultiplatformsandbox.core.common.build_info.BuildInfo
 import ru.lyrian.kotlinmultiplatformsandbox.core.common.constants.NapierConstants
 
 object SharedLogger {
@@ -42,15 +41,11 @@ object SharedLogger {
         throwable: Throwable? = null,
         tag: String? = null
     ) {
-        if(BuildInfo.isDebug) {
-            Napier.log(
-                priority = priority,
-                tag = NapierConstants.NAPIER_LOG_PREFIX + tag,
-                throwable = throwable,
-                message = message
-            )
-        } else {
-            // TODO -- do some firebase logging here for release build variant
-        }
+        Napier.log(
+            priority = priority,
+            tag = NapierConstants.NAPIER_LOG_PREFIX + tag,
+            throwable = throwable,
+            message = message
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/data/data_source/api/ApiClientResources.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/data/data_source/api/ApiClientResources.kt
@@ -1,9 +1,12 @@
 package ru.lyrian.kotlinmultiplatformsandbox.core.data.data_source.api
 
 import io.ktor.resources.Resource
+import kotlinx.serialization.Serializable
 
+@Serializable
 @Resource("/launches")
 class Launches {
+    @Serializable
     @Resource("/query")
     class Query(val parent: Launches = Launches())
 }

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/di/FeatureModules.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/di/FeatureModules.kt
@@ -1,9 +1,11 @@
 package ru.lyrian.kotlinmultiplatformsandbox.core.di
 
+import ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.di.firebaseIntegrationModule
 import ru.lyrian.kotlinmultiplatformsandbox.feature.launches.di.launchesModule
 import ru.lyrian.kotlinmultiplatformsandbox.feature.profile.di.profileModule
 
 fun featureModules() = listOf(
     launchesModule,
     profileModule,
+    firebaseIntegrationModule
 )

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/AppInitializer.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/AppInitializer.kt
@@ -5,8 +5,10 @@ import org.koin.core.component.inject
 
 class AppInitializer: KoinComponent {
     private val loggerInitializer: LoggerInitializer by inject()
+    private val firebaseInitializer: FirebaseInitializer by inject()
 
     fun init() {
         loggerInitializer.init()
+        firebaseInitializer.init()
     }
 }

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/FirebaseInitializer.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/FirebaseInitializer.kt
@@ -1,0 +1,5 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.initializers
+
+internal expect class FirebaseInitializer {
+    fun init()
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/FirebaseModule.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/FirebaseModule.kt
@@ -1,0 +1,5 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.initializers.di
+
+import org.koin.core.module.Module
+
+expect val firebaseModule: Module

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/InitializersModule.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/InitializersModule.kt
@@ -1,11 +1,12 @@
 package ru.lyrian.kotlinmultiplatformsandbox.core.initializers.di
 
-import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 import ru.lyrian.kotlinmultiplatformsandbox.core.initializers.AppInitializer
 import ru.lyrian.kotlinmultiplatformsandbox.core.initializers.LoggerInitializer
 
 internal val initializersModule = module {
-    singleOf(::LoggerInitializer)
-    singleOf(::AppInitializer)
+    factoryOf(::LoggerInitializer)
+    factoryOf(::AppInitializer)
+    includes(firebaseModule)
 }

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/data/repository/FirebaseIntegrationRepository.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/data/repository/FirebaseIntegrationRepository.kt
@@ -1,0 +1,6 @@
+package ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.data.repository
+
+internal class FirebaseIntegrationRepository {
+    @Suppress("TooGenericExceptionThrown")
+    fun generateException(): Nothing = throw RuntimeException("test")
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/di/FirebaseIntegrationModule.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/di/FirebaseIntegrationModule.kt
@@ -1,0 +1,11 @@
+package ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.di
+
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+import ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.data.repository.FirebaseIntegrationRepository
+import ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.domain.FirebaseIntegrationInteractor
+
+val firebaseIntegrationModule = module {
+    factoryOf(::FirebaseIntegrationRepository)
+    factoryOf(::FirebaseIntegrationInteractor)
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/domain/CrashBot.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/domain/CrashBot.kt
@@ -1,0 +1,45 @@
+package ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.domain
+
+import kotlin.random.Random
+
+class CrashBot {
+    private val dispatchCall = {
+        when(Random.nextInt(4)){
+            0 -> goCrash0()
+            1 -> goCrash1()
+            2 -> goCrash2()
+            3 -> goCrash3()
+        }
+    }
+
+    fun goCrash() {
+        internalDispatch()
+    }
+
+    private fun internalDispatch() = dispatchCall()
+
+    private fun internalDispatch1() = dispatchCall()
+
+    private fun internalDispatch2() = dispatchCall()
+
+    private fun goCrash0() {
+        internalDispatch()
+    }
+
+    private fun goCrash1() {
+        internalDispatch1()
+    }
+
+    private fun goCrash2() {
+        internalDispatch2()
+    }
+
+    private fun goCrash3() {
+        okCrash()
+    }
+
+    @Suppress("UseCheckOrError")
+    private fun okCrash(){
+        throw IllegalStateException("Nap time ...")
+    }
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/domain/FirebaseIntegrationInteractor.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/firebase_crashlytics_example/domain/FirebaseIntegrationInteractor.kt
@@ -1,0 +1,16 @@
+package ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.domain
+
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import ru.lyrian.kotlinmultiplatformsandbox.core.domain.SharedResult
+import ru.lyrian.kotlinmultiplatformsandbox.core.domain.runCatchingResult
+import ru.lyrian.kotlinmultiplatformsandbox.feature.firebase_crashlytics_example.data.repository.FirebaseIntegrationRepository
+
+class FirebaseIntegrationInteractor : KoinComponent {
+    private val firebaseIntegrationRepository: FirebaseIntegrationRepository by inject()
+
+    fun firebaseCrashlyticsTest(): SharedResult<Nothing, Throwable> =
+        runCatchingResult { firebaseIntegrationRepository.generateException() }
+
+    fun produceFatal() = CrashBot().goCrash()
+}

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/launches/domain/LaunchesInteractor.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/launches/domain/LaunchesInteractor.kt
@@ -4,10 +4,10 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import ru.lyrian.kotlinmultiplatformsandbox.core.data.pagination.PaginationProvider
 import ru.lyrian.kotlinmultiplatformsandbox.core.domain.SharedResult
-import ru.lyrian.kotlinmultiplatformsandbox.core.domain.asSharedResult
+import ru.lyrian.kotlinmultiplatformsandbox.core.domain.runCatchingResult
 import ru.lyrian.kotlinmultiplatformsandbox.feature.launches.data.repository.LaunchesRepository
 
-class LaunchesInteractor: KoinComponent {
+class LaunchesInteractor : KoinComponent {
     private val launchesRepository: LaunchesRepository by inject()
 
     /**
@@ -18,5 +18,5 @@ class LaunchesInteractor: KoinComponent {
 
     // Launches Details screen fetching cached launch data
     suspend fun getLaunchById(launchId: String): SharedResult<RocketLaunch, Throwable> =
-        runCatching { launchesRepository.getLaunchById(launchId) }.asSharedResult()
+        runCatchingResult { launchesRepository.getLaunchById(launchId) }
 }

--- a/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/profile/domain/ProfileInteractor.kt
+++ b/shared/src/commonMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/feature/profile/domain/ProfileInteractor.kt
@@ -3,14 +3,14 @@ package ru.lyrian.kotlinmultiplatformsandbox.feature.profile.domain
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import ru.lyrian.kotlinmultiplatformsandbox.core.domain.SharedResult
-import ru.lyrian.kotlinmultiplatformsandbox.core.domain.asSharedResult
+import ru.lyrian.kotlinmultiplatformsandbox.core.domain.runCatchingResult
 
 class ProfileInteractor : KoinComponent {
-    private val profileRepository: ProfileRepository by inject<ProfileRepository>()
+    private val profileRepository: ProfileRepository by inject()
 
     suspend fun getProfile(): SharedResult<Profile, Throwable> =
-        runCatching { profileRepository.getProfile() }.asSharedResult()
+        runCatchingResult { profileRepository.getProfile() }
 
     suspend fun saveProfile(profile: Profile): SharedResult<Unit, Throwable> =
-        runCatching { profileRepository.saveProfile(profile) }.asSharedResult()
+        runCatchingResult { profileRepository.saveProfile(profile) }
 }

--- a/shared/src/iosMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/FirebaseInitializer.kt
+++ b/shared/src/iosMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/FirebaseInitializer.kt
@@ -1,0 +1,14 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.initializers
+
+import co.touchlab.crashkios.crashlytics.enableCrashlytics
+import co.touchlab.crashkios.crashlytics.setCrashlyticsUnhandledExceptionHook
+import ru.lyrian.kotlinmultiplatformsandbox.core.common.build_info.BuildInfo
+
+internal actual class FirebaseInitializer {
+    actual fun init() {
+        if(!BuildInfo.isDebug) {
+            enableCrashlytics()
+            setCrashlyticsUnhandledExceptionHook()
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/LoggerInitializer.kt
+++ b/shared/src/iosMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/LoggerInitializer.kt
@@ -2,7 +2,15 @@ package ru.lyrian.kotlinmultiplatformsandbox.core.initializers
 
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import ru.lyrian.kotlinmultiplatformsandbox.core.common.build_info.BuildInfo
+import ru.lyrian.kotlinmultiplatformsandbox.core.common.logger.NapierCrashlyticsLogger
 
 internal actual class LoggerInitializer {
-    actual fun init() = Napier.base(DebugAntilog())
+    actual fun init() {
+        if(BuildInfo.isDebug) {
+            Napier.base(antilog = DebugAntilog())
+        } else {
+            Napier.base(antilog = NapierCrashlyticsLogger())
+        }
+    }
 }

--- a/shared/src/iosMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/FirebaseModule.kt
+++ b/shared/src/iosMain/kotlin/ru/lyrian/kotlinmultiplatformsandbox/core/initializers/di/FirebaseModule.kt
@@ -1,0 +1,10 @@
+package ru.lyrian.kotlinmultiplatformsandbox.core.initializers.di
+
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+import ru.lyrian.kotlinmultiplatformsandbox.core.initializers.FirebaseInitializer
+
+actual val firebaseModule: Module = module {
+    factoryOf(::FirebaseInitializer)
+}


### PR DESCRIPTION
- Removed redundant ios framework declaration
- Refactored custom SharedResult to extension context function
- Removed unnecessary test function from FirebaseIntegrationInteractor.kt
- Disabled bytecode generation
- Implemented crashkios as Version Catalog dependency
- Provided native coroutines plugin with buildSrc classpath implementation
- Added toggle to switch Napier config depend on current build config
- Fixed proguard errors by adding @Serializable annotation to @Resource annotated classes